### PR TITLE
chore: add Reason() method to VmError interface

### DIFF
--- a/x/evm/types/errors.go
+++ b/x/evm/types/errors.go
@@ -128,6 +128,7 @@ type VmError interface {
 	Error() string
 	VmError() string
 	Ret() []byte
+	Reason() string
 }
 
 type vmErrorWithRet struct {

--- a/x/evm/types/errors_test.go
+++ b/x/evm/types/errors_test.go
@@ -51,3 +51,54 @@ func TestNewExecErrorWithReason(t *testing.T) {
 		require.Equal(t, 3, errWithReason.ErrorCode())
 	}
 }
+
+func TestNewVmErrorWithRet(t *testing.T) {
+	testCases := []struct {
+		name   string
+		vmErr  string
+		reason string
+		ret    []byte
+		hash   string
+	}{
+		{
+			"Empty reason",
+			"execution reverted",
+			"",
+			nil,
+			"0x",
+		},
+		{
+			"With unpackable reason",
+			"execution reverted",
+			"",
+			[]byte("a"),
+			"0x61",
+		},
+		{
+			"With packable reason but empty reason",
+			"execution reverted",
+			"",
+			revertSelector,
+			"0x08c379a0",
+		},
+		{
+			"With packable reason with reason",
+			"execution reverted",
+			"COUNTER_TOO_LOW",
+			hexutils.HexToBytes("08C379A00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000F434F554E5445525F544F4F5F4C4F570000000000000000000000000000000000"),
+			"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000f434f554e5445525f544f4f5f4c4f570000000000000000000000000000000000",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		vmErrorWithRet := NewVmErrorWithRet(
+			tc.vmErr,
+			tc.ret,
+			tc.hash,
+			0,
+		)
+		require.Equal(t, tc.vmErr, vmErrorWithRet.VmError())
+		require.Equal(t, tc.reason, vmErrorWithRet.Reason())
+	}
+}


### PR DESCRIPTION
This PR just adds the `Reason` method to the `VmError` interface.
The method is already implemented by `vmErrorWithRet`.
It's useful to have access to the `reason` field when there's and `execution reverted` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `Reason()` method to provide detailed error information for EVM execution failures.
	- Enhanced error reporting by including a reason field in the VM error structure.

- **Bug Fixes**
	- Improved clarity of error handling by formatting revert reasons in error messages.

- **Tests**
	- Added a new test function to validate the behavior of the updated VM error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->